### PR TITLE
Refactoring, now uses a render prop instead of a pure HOC

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,2 @@
+import '@storybook/addon-actions/register';
+import '@storybook/addon-links/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,9 @@
+import { configure } from '@storybook/react';
+
+// automatically import all files ending in *.stories.js
+const req = require.context('../stories', true, /.stories.js$/);
+function loadStories() {
+  req.keys().forEach(filename => req(filename));
+}
+
+configure(loadStories, module);

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "stable"
+branches:
+  only:
+  - master
+cache:
+  directories:
+    - "node_modules"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
-# react-is-visible
+# React Is Visible
+
+[![build status](https://img.shields.io/travis/lessp/react-is-visible/master.svg?style=flat-square)](https://travis-ci.org/lessp/react-is-visible)
+[![dependencies Status](https://david-dm.org/lessp/react-is-visible/status.svg?style=flat-square)](https://david-dm.org/lessp/react-is-visible)
+
+...
+
+Uses the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver).
+
+## Polyfill
+
+In order to polyfill, install the [polyfill from W3C](https://github.com/w3c/IntersectionObserver/tree/master/polyfill)
+
+    $ npm install intersection-observer --save
+
+... and import it before importing `'react-is-visible'`
+
+eg.
+
+```jsx
+// App.js
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "intersection-observer";
+import { withIsVisible } from "react-is-visible";
+
+// ...
+```
+
+## Installation
+
+    $ npm install react-is-visible --save
+
+or
+
+    $ yarn add react-is-visible
+
+## Usage
+
+### React Is Visible
+
+#### HOC
+
+```jsx
+import React from "react";
+import { withIsVisible } from "react-is-visible";
+
+const SomeComponent = ({ isVisible }) => <h1>{isVisible && `I'm visible!`}</h1>;
+
+export default withIsVisible(SomeComponent);
+```
+
+or as a decorator
+
+```jsx
+import React from "react";
+import { withIsVisible } from "react-is-visible";
+
+@withIsVisible
+class SomeClass extends React.Component {
+  render() {
+    const { isVisible } = this.props;
+
+    return <h1>{isVisible && `I'm visible!`}</h1>;
+  }
+}
+```
+
+#### Render Prop
+
+```jsx
+import React from "react";
+import { IsVisible } from "react-is-visible";
+
+const App = () => (
+  <IsVisible>{isVisible => <h1>{isVisible && `I'm visible!`}</h1>}</IsVisible>
+);
+```
+
+## API
+
+...
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
   "name": "react-is-visible",
   "version": "0.0.1",
-  "description": "A simple HOC that passes a visibilityStatus-prop to components that are using it.",
+  "description": "A simple library that passes an 'isVisible'-prop to components that are using it.",
   "keywords": [
     "intersection",
     "observer",
     "visible",
+    "invisible",
     "visibility"
   ],
-  "main": "lib/withIsVisible.js",
+  "main": "lib/index.js",
   "scripts": {
     "build": "rimraf lib && babel src/ -d lib/",
-    "test": "jest"
+    "test": "jest",
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook"
   },
   "repository": {
     "type": "git",
@@ -40,6 +43,12 @@
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-test-renderer": "^16.3.2",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "@storybook/react": "^3.4.2",
+    "@storybook/addon-actions": "^3.4.2",
+    "@storybook/addon-links": "^3.4.2",
+    "@storybook/addons": "^3.4.2",
+    "babel-core": "^6.26.0",
+    "babel-runtime": "^6.26.0"
   }
 }

--- a/src/IsVisible.js
+++ b/src/IsVisible.js
@@ -1,0 +1,44 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import VO from "./VisibilityObserver";
+
+class IsVisible extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
+
+    this.state = {
+      isVisible: false
+    };
+  }
+
+  componentDidMount() {
+    this.unwatch = VO.watch(
+      ReactDOM.findDOMNode(this),
+      this.handleVisibilityChange
+    );
+  }
+
+  componentWillUnmount() {
+    this.unwatch();
+  }
+
+  handleVisibilityChange({ isIntersecting }) {
+    if (this.state.isVisible === isIntersecting) return;
+
+    this.setState({
+      isVisible: isIntersecting
+    });
+  }
+
+  render() {
+    const { isVisible } = this.state;
+
+    const renderedChildren = this.props.children(isVisible);
+    return renderedChildren && React.Children.only(renderedChildren);
+  }
+}
+
+export default IsVisible;

--- a/src/VisibilityObserver.js
+++ b/src/VisibilityObserver.js
@@ -1,11 +1,11 @@
+import "intersection-observer";
+
 let intersectionObserver;
 let intersectionObserverOptions = {};
 let subscribers = new Map();
 
-const handleIntersections = entries => entries.forEach(passVisibilityStatus);
-
-const passVisibilityStatus = entry =>
-  subscribers.get(entry.target).call(this, entry);
+const handleIntersections = entries =>
+  entries.forEach(entry => subscribers.get(entry.target).call(this, entry));
 
 const getIntersectionObserver = () => {
   if (!intersectionObserver) {
@@ -42,8 +42,4 @@ const unwatch = domNode => {
   }
 };
 
-const emit = (subscriber, details) => {
-  subscribers.get(subscriber)(details);
-};
-
-export default { watch, unwatch };
+export default { watch, unwatch, setIntersectionObserverOptions };

--- a/src/VisibilityObserver.js
+++ b/src/VisibilityObserver.js
@@ -1,5 +1,3 @@
-import "intersection-observer";
-
 let intersectionObserver;
 let intersectionObserverOptions = {};
 let subscribers = new Map();

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+import { withIsVisible } from "./withIsVisible";
+import IsVisible from "./IsVisible";
+
+export { IsVisible as default, withIsVisible };

--- a/src/withIsVisible.js
+++ b/src/withIsVisible.js
@@ -3,60 +3,19 @@ import ReactDOM from "react-dom";
 
 import hoistNonReactStatic from "hoist-non-react-statics";
 
-import VO from "./VisibilityObserver";
+import IsVisible from "./IsVisible";
 
 const getDisplayName = WrappedComponent =>
   WrappedComponent.displayName || WrappedComponent.name || "Component";
 
 export const withIsVisible = WrappedComponent => {
-  class WithIsVisible extends React.Component {
-    constructor(props) {
-      super(props);
-
-      this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
-
-      this.state = {
-        visibilityStatus: {
-          isVisible: false,
-          details: {}
-        }
-      };
-    }
-
-    componentDidMount() {
-      this.unwatch = VO.watch(
-        ReactDOM.findDOMNode(this),
-        this.handleVisibilityChange
-      );
-    }
-
-    componentWillUnmount() {
-      this.unwatch();
-    }
-
-    handleVisibilityChange({ isIntersecting, boundingClientRect, time }) {
-      this.setState({
-        visibilityStatus: {
-          isVisible: isIntersecting,
-          details: {
-            boundingClientRect,
-            time
-          }
-        }
-      });
-    }
-
-    render() {
-      const { forwardedRef, ...props } = this.props;
-      return (
-        <WrappedComponent
-          visibilityStatus={this.state.visibilityStatus}
-          ref={forwardedRef}
-          {...props}
-        />
-      );
-    }
-  }
+  const WithIsVisible = ({ forwardedRef, ...props }) => (
+    <IsVisible
+      children={isVisible => (
+        <WrappedComponent {...props} isVisible={isVisible} ref={forwardedRef} />
+      )}
+    />
+  );
 
   /* Display name */
   WithIsVisible.displayName = `WithIsVisible(${getDisplayName(

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -1,0 +1,39 @@
+import React from "react";
+
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+
+import IsVisible, { withIsVisible } from "../src";
+
+const basicStyling = {
+  height: "300vh",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  fontFamily: "sans-serif"
+};
+
+/* Functional Component */
+const FunctionalComponent = ({ isVisible }) => (
+  <h1>{isVisible && `I'm visible!`}</h1>
+);
+
+/* with withIsVisible */
+const FunctionalComponentWithIsVisible = withIsVisible(FunctionalComponent);
+
+storiesOf("React Is Visible", module)
+  .add("as HOC", () => (
+    <div style={basicStyling}>
+      <FunctionalComponentWithIsVisible />
+    </div>
+  ))
+  .add("as Render Prop", () => (
+    <div style={basicStyling}>
+      <IsVisible>
+        {isVisible => (
+          <FunctionalComponentWithIsVisible isVisible={isVisible} />
+        )}
+      </IsVisible>
+    </div>
+  ));

--- a/tests/hoc.test.js
+++ b/tests/hoc.test.js
@@ -3,13 +3,11 @@ import ReactDOM from "react-dom";
 
 import renderer from "react-test-renderer";
 
-import VisibilityObserver from "../src/VisibilityObserver";
-import { withIsVisible } from "../src/withIsVisible";
-
 /* Enzyme */
-import { configure, shallow, mount, render } from "enzyme";
-import Adapter from "enzyme-adapter-react-16";
-configure({ adapter: new Adapter() });
+import { shallow, mount, render } from "enzyme";
+import "./setup.js";
+
+import { withIsVisible } from "../src/withIsVisible";
 
 let FunctionalComponent = ({ visibilityStatus, ...props }) => <h1 {...props} />;
 FunctionalComponent = withIsVisible(FunctionalComponent);
@@ -72,19 +70,3 @@ describe("withIsVisible", () => {
     component.unmount();
   });
 });
-
-/**
- * TODO: Add these tests and think about how to make these less tightly coupled
-describe("VisibilityObserver", () => {
-  it("adds a wrapped component to subscriber list", () => {
-    const component = mount(<FunctionalComponent />);
-
-    component.unmount();
-  });
-  it("removes a wrapped component from subscriber list on unmount", () => {
-    const component = mount(<FunctionalComponent />);
-
-    component.unmount();
-  });
-});
-*/

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,3 @@
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+configure({ adapter: new Adapter() });

--- a/tests/vo.test.js
+++ b/tests/vo.test.js
@@ -1,0 +1,38 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import renderer from "react-test-renderer";
+
+/* Enzyme */
+import { shallow, mount, render } from "enzyme";
+import "./setup.js";
+
+import VisibilityObserver from "../src/VisibilityObserver";
+
+let FunctionalComponent = ({ visibilityStatus, ...props }) => <h1 {...props} />;
+FunctionalComponent = withIsVisible(FunctionalComponent);
+
+class ClassComponent extends React.Component {
+  render() {
+    const { visibilityStatus, ...props } = this.props;
+
+    return <h1 {...props} />;
+  }
+}
+ClassComponent = withIsVisible(ClassComponent);
+
+/**
+ * TODO: Add these tests and think about how to make these less tightly coupled
+describe("VisibilityObserver", () => {
+  it("adds a wrapped component to subscriber list", () => {
+    const component = mount(<FunctionalComponent />);
+
+    component.unmount();
+  });
+  it("removes a wrapped component from subscriber list on unmount", () => {
+    const component = mount(<FunctionalComponent />);
+
+    component.unmount();
+  });
+});
+*/


### PR DESCRIPTION
There's currently an issue with the render prop losing its domNode reference (see #4), this is afaik only an issue when used as render prop and does not affect HOC

